### PR TITLE
Use new FormattedMessage objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
-dependencies = ["relic-tool-sga-core >= 2.0.0", "ply >= 3.11"]
+dependencies = ["relic-tool-sga-core >= 2.0.0", "ply >= 3.11", "relic-tool-core>=2.3.0"]
 description = "A plugin to read/write Relic SGA (V2) archive files."
 dynamic = ["version"]
 name = "relic-tool-sga-v2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fs >= 2.4.16
 ply >= 3.11
+relic-tool-core>=2.3.0
 relic-tool-sga-core>=2.0.0

--- a/src/relic/sga/v2/__init__.py
+++ b/src/relic/sga/v2/__init__.py
@@ -6,7 +6,7 @@ from relic.sga.v2.definitions import (
 
 from relic.sga.v2.essencefs import EssenceFSV2Opener, EssenceFSV2
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 __all__ = [
     "EssenceFSV2Opener",

--- a/src/relic/sga/v2/arciv/__init__.py
+++ b/src/relic/sga/v2/arciv/__init__.py
@@ -7,30 +7,32 @@ from relic.sga.v2.arciv.lexer import build as build_lexer
 from relic.sga.v2.arciv.parser import build as build_parser
 from relic.sga.v2.arciv.writer import ArcivWriter, ArcivWriterSettings, ArcivEncoder
 
+from relic.core.logmsg import BraceMessage
+
 logger = logging.getLogger(__name__)
 
 
 def load(f: TextIO) -> Arciv:
-    logger.debug("Loading Arciv File: {0}", f)
+    logger.debug(BraceMessage("Loading Arciv File: {0}", f))
     data = parse(f)
     return Arciv.from_parser(data)
 
 
 def loads(f: str) -> Arciv:
-    logger.debug("Loading Arciv string: `{0}`", f)
+    logger.debug(BraceMessage("Loading Arciv string: `{0}`", f))
     data = parses(f)
     return Arciv.from_parser(data)
 
 
 def parse(f: TextIO) -> Dict[str, Any]:
-    logger.debug("Parsing Arciv File: `{0}`", f)
+    logger.debug(BraceMessage("Parsing Arciv File: `{0}`", f))
     lexer = build_lexer()
     parser = build_parser()
     return parser.parse(f.read(), lexer=lexer)  # type: ignore
 
 
 def parses(f: str) -> Dict[str, Any]:
-    logger.debug("Parsing Arciv string: `{0}`", f)
+    logger.debug(BraceMessage("Parsing Arciv string: `{0}`", f))
     with StringIO(f) as h:
         return parse(h)
 
@@ -41,7 +43,7 @@ def dump(
     settings: Optional[ArcivWriterSettings] = None,
     encoder: Optional[ArcivEncoder] = None,
 ) -> None:
-    logger.debug("Dumping Arciv object `{0}` to `{1}`", data, f)
+    logger.debug(BraceMessage("Dumping Arciv object `{0}` to `{1}`", data, f))
     _writer = ArcivWriter(settings=settings, encoder=encoder)
     _writer.writef(f, data)
 
@@ -51,7 +53,7 @@ def dumps(
     settings: Optional[ArcivWriterSettings] = None,
     encoder: Optional[ArcivEncoder] = None,
 ) -> str:
-    logger.debug("Dumping Arciv object `{0}` to string", data)
+    logger.debug(BraceMessage("Dumping Arciv object `{0}` to string", data))
     with StringIO() as h:
         dump(h, data, settings=settings, encoder=encoder)
         return h.getvalue()

--- a/src/relic/sga/v2/arciv/definitions.py
+++ b/src/relic/sga/v2/arciv/definitions.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass
 from os import PathLike
 from typing import Dict, Any, List, Union, Optional
+from relic.core.logmsg import BraceMessage
 
 from relic.sga.core.definitions import StorageType
 from relic.sga.v2.arciv.errors import ArcivLayoutError
@@ -40,7 +41,7 @@ class TocFileItem(_ArcivSpecialEncodable):
 
     @classmethod
     def from_parser(cls, d: Dict[str, Any]) -> TocFileItem:
-        _module_logger.debug("Parsing {0} : {1}", cls.__name__, d)
+        _module_logger.debug(BraceMessage("Parsing {0} : {1}", cls.__name__, d))
         try:
             storage_value: int = d["Store"]
             if storage_value == -1:
@@ -56,10 +57,14 @@ class TocFileItem(_ArcivSpecialEncodable):
             raise ArcivLayoutError from e
 
     def to_parser_dict(self) -> Any:
-        _module_logger.debug("Converting {0} to dictionary", self.__class__.__name__)
+        _module_logger.debug(
+            BraceMessage("Converting {0} to dictionary", self.__class__.__name__)
+        )
         obj = dataclasses.asdict(self)
         obj["Store"] = self.Store.value if self.Store is not None else -1
-        _module_logger.debug("Converted {0} to {1}", self.__class__.__name__, obj)
+        _module_logger.debug(
+            BraceMessage("Converted {0} to {1}", self.__class__.__name__, obj)
+        )
         return obj
 
 
@@ -77,7 +82,7 @@ class TocFolderItem:
 
     @classmethod
     def from_parser(cls, d: Dict[str, Any]) -> TocFolderItem:
-        _module_logger.debug("Parsing {0} : {1}", cls.__name__, d)
+        _module_logger.debug(BraceMessage("Parsing {0} : {1}", cls.__name__, d))
         try:
             files = [TocFileItem.from_parser(file) for file in d["Files"]]
             folders = [TocFolderItem.from_parser(folder) for folder in d["Folders"]]
@@ -124,7 +129,7 @@ class TocHeader:
 
     @classmethod
     def from_parser(cls, d: Dict[str, Any]) -> TocHeader:
-        _module_logger.debug("Parsing {0} : {1}", cls.__name__, d)
+        _module_logger.debug(BraceMessage("Parsing {0} : {1}", cls.__name__, d))
         try:
             storage = [TocStorage.from_parser(item) for item in d["Storage"]]
             kwargs = d.copy()
@@ -141,7 +146,7 @@ class TocItem:
 
     @classmethod
     def from_parser(cls, d: Dict[str, Any]) -> TocItem:
-        _module_logger.debug("Parsing {0} : {1}", cls.__name__, d)
+        _module_logger.debug(BraceMessage("Parsing {0} : {1}", cls.__name__, d))
         try:
             toc_header = TocHeader.from_parser(d["TOCHeader"])
             root_folder = TocFolderItem.from_parser(d["RootFolder"])
@@ -164,7 +169,7 @@ class Arciv(_ArcivSpecialEncodable):
     @classmethod
     def from_parser(cls, d: Dict[str, Any]) -> Arciv:
         """Converts a parser result to a formatted."""
-        _module_logger.debug("Parsing {0} : {1}", cls.__name__, d)
+        _module_logger.debug(BraceMessage("Parsing {0} : {1}", cls.__name__, d))
         try:
             root_dict = d["Archive"]
             header_dict = root_dict["ArchiveHeader"]
@@ -179,5 +184,7 @@ class Arciv(_ArcivSpecialEncodable):
             raise ArcivLayoutError from e
 
     def to_parser_dict(self) -> Dict[str, Any]:
-        _module_logger.debug("Converting {0} to dictionary", self.__class__.__name__)
+        _module_logger.debug(
+            BraceMessage("Converting {0} to dictionary", self.__class__.__name__)
+        )
         return {"Archive": dataclasses.asdict(self)}

--- a/src/relic/sga/v2/arciv/writer.py
+++ b/src/relic/sga/v2/arciv/writer.py
@@ -8,6 +8,7 @@ from io import StringIO
 from logging import getLogger
 from os import PathLike
 from typing import Optional, Iterable, Union, List, Dict, Any, TextIO, Iterator
+from relic.core.logmsg import BraceMessage
 
 from relic.core.errors import RelicToolError
 from relic.sga.v2.arciv.errors import ArcivWriterError, ArcivEncoderError
@@ -50,10 +51,10 @@ class ArcivWriter:
         A context manager that manages the indent level of the writer
         """
         self._indent_level += 1
-        logger.debug("Entering Indent `{0}`", self._indent_level)
+        logger.debug(BraceMessage("Entering Indent `{0}`", self._indent_level))
         yield None
         self._indent_level -= 1
-        logger.debug("Exiting Indent `{0}`", self._indent_level)
+        logger.debug(BraceMessage("Exiting Indent `{0}`", self._indent_level))
 
     def _formatted(
         self,
@@ -66,12 +67,14 @@ class ArcivWriter:
         Returns a list of formatted tokens
         """
         logger.debug(
-            "Formatting `{0}` (newline:{1}, comma:{2}, no_indent:{3}, _indent_level:{4})",
-            values,
-            newline,
-            comma,
-            no_indent,
-            self._indent_level,
+            BraceMessage(
+                "Formatting `{0}` (newline:{1}, comma:{2}, no_indent:{3}, _indent_level:{4})",
+                values,
+                newline,
+                comma,
+                no_indent,
+                self._indent_level,
+            )
         )
 
         if (
@@ -98,10 +101,12 @@ class ArcivWriter:
         Formats a number-like as a string (formatted as an string) in the 'arciv' specification
         """
         logger.debug(
-            "Formatting String `{0}` (in_collection:{1}, in_assignment:{2})",
-            value,
-            in_collection,
-            in_assignment,
+            BraceMessage(
+                "Formatting String `{0}` (in_collection:{1}, in_assignment:{2})",
+                value,
+                in_collection,
+                in_assignment,
+            )
         )
         yield from self._formatted(
             f'"{value}"',
@@ -121,10 +126,12 @@ class ArcivWriter:
         Formats a number-like as a string (formatted as an int object) in the 'arciv' specification
         """
         logger.debug(
-            "Formatting Number `{0}` (in_collection:{1}, in_assignment:{2})",
-            value,
-            in_collection,
-            in_assignment,
+            BraceMessage(
+                "Formatting Number `{0}` (in_collection:{1}, in_assignment:{2})",
+                value,
+                in_collection,
+                in_assignment,
+            )
         )
         yield from self._formatted(
             str(value),
@@ -144,10 +151,12 @@ class ArcivWriter:
         Formats a string-like as a string (formatted as a path object) in the 'arciv' specification
         """
         logger.debug(
-            "Formatting Path `{0}` (in_collection:{1}, in_assignment:{2})",
-            value,
-            in_collection,
-            in_assignment,
+            BraceMessage(
+                "Formatting Path `{0}` (in_collection:{1}, in_assignment:{2})",
+                value,
+                in_collection,
+                in_assignment,
+            )
         )
         yield from self._formatted(
             f"[[{os.fspath(value)}]]",
@@ -167,10 +176,12 @@ class ArcivWriter:
         Formats a collection as a string in the 'arciv' specification
         """
         logger.debug(
-            "Formatting Collection `{0}` (in_collection:{1}, in_assignment:{2})",
-            encoded,
-            in_collection,
-            in_assignment,
+            BraceMessage(
+                "Formatting Collection `{0}` (in_collection:{1}, in_assignment:{2})",
+                encoded,
+                in_collection,
+                in_assignment,
+            )
         )
         if in_assignment:
             yield from self._formatted(newline=True)
@@ -209,11 +220,13 @@ class ArcivWriter:
         Formats an arbitrary value as a string in the 'arciv' specification
         """
         logger.debug(
-            "Formatting Item `{0}` (in_collection:{1}, in_assignment:{2}, encode:{3})",
-            value,
-            in_collection,
-            in_assignment,
-            encode,
+            BraceMessage(
+                "Formatting Item `{0}` (in_collection:{1}, in_assignment:{2}, encode:{3})",
+                value,
+                in_collection,
+                in_assignment,
+                encode,
+            )
         )
         encoded = self._encoder.default(value) if encode else value
         if isinstance(encoded, (list, dict)):
@@ -244,10 +257,12 @@ class ArcivWriter:
         Formats a key-value pair into a string in the 'arciv' specification
         """
         logger.debug(
-            "Formatting Key/Value `{0}`/`{1}` (in_collection:{2})",
-            key,
-            value,
-            in_collection,
+            BraceMessage(
+                "Formatting Key/Value `{0}`/`{1}` (in_collection:{2})",
+                key,
+                value,
+                in_collection,
+            )
         )
         yield from self._formatted(key, "=")
         if self._settings.has_whitespace:
@@ -260,7 +275,7 @@ class ArcivWriter:
         """
         Converts the given data into string tokens that can be written to a file
         """
-        logger.debug("Iterating Tokens on {0}", data)
+        logger.debug(BraceMessage("Iterating Tokens on {0}", data))
         encoded = self._encoder.default(data)
         if not isinstance(encoded, dict):
             raise RelicToolError(
@@ -273,7 +288,7 @@ class ArcivWriter:
         """
         Writes the data to a string, using the 'arciv' specification.
         """
-        logger.debug("Writing Arciv data {0} to string", data)
+        logger.debug(BraceMessage("Writing Arciv data {0} to string", data))
         with StringIO() as fp:
             self.writef(fp, data)
             return fp.getvalue()
@@ -282,7 +297,7 @@ class ArcivWriter:
         """
         Writes the data to the file handle, using the 'arciv' specification.
         """
-        logger.debug("Writing Arciv data {0} to file {1}", data, fp)
+        logger.debug(BraceMessage("Writing Arciv data {0} to file {1}", data, fp))
         for token in self.tokens(data):
             fp.write(token)
 

--- a/src/relic/sga/v2/cli.py
+++ b/src/relic/sga/v2/cli.py
@@ -14,6 +14,7 @@ from relic.sga.v2 import arciv
 from relic.sga.v2.arciv import Arciv
 from relic.sga.v2.essencefs.definitions import SgaFsV2Packer, EssenceFSV2
 from relic.sga.v2.serialization import SgaV2GameFormat
+from relic.core.logmsg import BraceMessage
 
 _CHUNK_SIZE = 1024 * 1024 * 4  # 4 MiB
 
@@ -97,7 +98,11 @@ class RelicSgaPackV2Cli(CliPlugin):
 
         # Execute Command
         logger.info("SGA Packer")
-        logger.info(f"\tReading Manifest `{manifest_path}`")
+        logger.info(
+            BraceMessage(
+                "\tReading Manifest `{manifest_path}`", manifest_path=manifest_path
+            )
+        )
         with open(manifest_path, "r", encoding="utf-8") as manifest_handle:
             if manifest_is_json:
                 manifest_json: Dict[str, Any] = json.load(manifest_handle)
@@ -114,7 +119,9 @@ class RelicSgaPackV2Cli(CliPlugin):
             os.makedirs(out_path, exist_ok=True)
         # Create full path
         full_out_path = os.path.join(out_path, file_name)
-        logger.info(f"\tPacking SGA `{full_out_path}`")
+        logger.info(
+            BraceMessage("\tPacking SGA `{full_out_path}`", full_out_path=full_out_path)
+        )
         with open(full_out_path, "wb") as out_handle:
             SgaFsV2Packer.pack(manifest, out_handle, safe_mode=True)
         logger.info("\t\tPacked")
@@ -153,12 +160,18 @@ class RelicSgaRepackV2Cli(CliPlugin):
         # Execute Command
 
         if out_sga is None:
-            logger.info(f"Re-Packing `{in_sga}`")
+            logger.info(BraceMessage("Re-Packing `{in_sga}`", in_sga=in_sga))
         else:
-            logger.info(f"Re-Packing `{in_sga}` as `{out_sga}`")
+            logger.info(
+                BraceMessage(
+                    "Re-Packing `{in_sga}` as `{out_sga}`",
+                    in_sga=in_sga,
+                    out_sga=out_sga,
+                )
+            )
 
         # Create 'SGA'
-        logger.info(f"\tReading `{in_sga}`")
+        logger.info(BraceMessage("\tReading `{in_sga}`", in_sga=in_sga))
         if "Dawn of War" in in_sga:
             game_format = SgaV2GameFormat.DawnOfWar
         elif "Impossible Creatures" in in_sga:
@@ -175,7 +188,7 @@ class RelicSgaRepackV2Cli(CliPlugin):
             )
             # Write to binary file:
             if out_sga is not None:
-                logger.info(f"\tWriting `{out_sga}`")
+                logger.info(BraceMessage("\tWriting `{out_sga}`", out_sga=out_sga))
 
                 with open(out_sga, "wb") as sga_file:
                     sgafs.save(sga_file)

--- a/src/relic/sga/v2/essencefs/definitions.py
+++ b/src/relic/sga/v2/essencefs/definitions.py
@@ -13,6 +13,7 @@ from os import PathLike
 from pathlib import PureWindowsPath
 from threading import RLock
 from types import TracebackType
+from relic.core.logmsg import BraceMessage
 from typing import (
     BinaryIO,
     List,
@@ -161,7 +162,9 @@ class SgaPathResolver:
 
     @classmethod
     def build(cls, *path: str, alias: Optional[str] = None) -> str:
-        logger.debug("Building path given `{0}` & alias: `{1}`", path, alias)
+        logger.debug(
+            BraceMessage("Building path given `{0}` & alias: `{1}`", path, alias)
+        )
         full_path = cls.join(*path)
         full_path = cls.fix_case(full_path)
         if alias:
@@ -174,7 +177,7 @@ class SgaPathResolver:
 
     @classmethod
     def parse(cls, path: str) -> Tuple[Optional[str], str]:
-        logger.debug("Parsing path `{0}` into alias/path tuple", path)
+        logger.debug(BraceMessage("Parsing path `{0}` into alias/path tuple", path))
         if ":" in path:
             alias, path = path.split(":", maxsplit=1)
         else:
@@ -184,21 +187,25 @@ class SgaPathResolver:
     @classmethod
     def fix_seperator(cls, path: str) -> str:
         logger.debug(
-            "Fixing Seperator in `{0}` (`{1}` => `{2}`)", path, cls.INV_SEP, cls.SEP
+            BraceMessage(
+                "Fixing Seperator in `{0}` (`{1}` => `{2}`)", path, cls.INV_SEP, cls.SEP
+            )
         )
         return path.replace(cls.INV_SEP, cls.SEP)
 
     @classmethod
     def fix_case(cls, path: str) -> str:
-        logger.debug("Fix Case in `{0}` (`upper` => `lower`)", path)
+        logger.debug(BraceMessage("Fix Case in `{0}` (`upper` => `lower`)", path))
         return path.lower()
 
     @classmethod
     def split_parts(cls, path: str, include_root: bool = True) -> List[str]:
         logger.debug(
-            "Separating `{0}` into parts{1}",
-            path,
-            " (including root)" if include_root else "",
+            BraceMessage(
+                "Separating `{0}` into parts{1}",
+                path,
+                " (including root)" if include_root else "",
+            )
         )
         path = cls.fix_seperator(path)
         path = cls.fix_case(path)
@@ -222,9 +229,11 @@ class SgaPathResolver:
     @classmethod
     def join(cls, *parts: str, add_root: bool = False) -> str:
         logger.debug(
-            "Joining `{0}`{1}",
-            parts,
-            " (and adding root `" + cls.ROOT + "`)" if add_root else "",
+            BraceMessage(
+                "Joining `{0}`{1}",
+                parts,
+                " (and adding root `" + cls.ROOT + "`)" if add_root else "",
+            )
         )
         fixed_parts = (cls.fix_seperator(part) for part in parts)
         result = ""
@@ -242,7 +251,7 @@ class SgaPathResolver:
 
     @classmethod
     def split(cls, path: str) -> Tuple[str, str]:
-        logger.debug("Splitting `{0}` into head, tail", path)
+        logger.debug(BraceMessage("Splitting `{0}` into head, tail", path))
         parts = cls.split_parts(path)
         if len(parts) > 0:
             return cls.join(*parts[:-1]), parts[-1]
@@ -250,19 +259,19 @@ class SgaPathResolver:
 
     @classmethod
     def strip_root(cls, path: str) -> str:
-        logger.debug("Stripping root from `{0}`", path)
+        logger.debug(BraceMessage("Stripping root from `{0}`", path))
         if len(path) > 0 and path[0] == cls.ROOT:
             return path[1:]
         return path
 
     @classmethod
     def basename(cls, path: str) -> str:
-        logger.debug("Getting basename of `{0}`", path)
+        logger.debug(BraceMessage("Getting basename of `{0}`", path))
         return cls.split(path)[1]
 
     @classmethod
     def dirname(cls, path: str) -> str:
-        logger.debug("Getting dirname of `{0}`", path)
+        logger.debug(BraceMessage("Getting dirname of `{0}`", path))
         return cls.split(path)[0]
 
 
@@ -345,7 +354,7 @@ class SgaFsFileV2Lazy(_SgaFsFileV2):
         return self._info.storage_type
 
     def getinfo(self, namespaces: Optional[Collection[str]] = None) -> Info:
-        logger.debug("Getting Info for `{0}` (LazyInfo)", self.name)
+        logger.debug(BraceMessage("Getting Info for `{0}` (LazyInfo)", self.name))
         if namespaces is None:
             namespaces = []
 
@@ -382,7 +391,7 @@ class SgaFsFileV2Lazy(_SgaFsFileV2):
             yield self._data_info.data(decompress=True)
 
     def verify_crc32(self, error: bool) -> bool:
-        logger.debug("Verifying CRC32 for `{0}` (LazyFile)", self.name)
+        logger.debug(BraceMessage("Verifying CRC32 for `{0}` (LazyFile)", self.name))
         # Locking should be handled by opening file, no need to lock here
         with self.openbin("r") as stream:
             expected = self._data_info.header.crc32
@@ -473,7 +482,7 @@ class SgaFsFileV2Mem(_SgaFsFileV2):  # pylint: disable=r0902
         return RelicDateTimeSerializer.datetime2unix(self._modified)
 
     def getinfo(self, namespaces: Optional[Collection[str]] = None) -> Info:
-        logger.debug("Getting Info for `{0}` (MemFile)", self.name)
+        logger.debug(BraceMessage("Getting Info for `{0}` (MemFile)", self.name))
         if namespaces is None:
             namespaces = []
 
@@ -488,7 +497,9 @@ class SgaFsFileV2Mem(_SgaFsFileV2):  # pylint: disable=r0902
 
     def setinfo(self, info: Mapping[str, Mapping[str, object]]) -> None:
         logger.debug(
-            "Setting (Updating) Info for `{0}` (MemFile) to `{1}`", self.name, info
+            BraceMessage(
+                "Setting (Updating) Info for `{0}` (MemFile) to `{1}`", self.name, info
+            )
         )
         if NS_DETAILS in info:
             self._modified = info[NS_DETAILS]["modified"]  # type: ignore
@@ -1071,7 +1082,7 @@ class _V2TocDisassembler:  # pylint:disable=r0902
         self._drive_count = 0
 
     def _write_name_to_table(self, table: Dict[str, int], name: str) -> int:
-        logger.debug("Writing `{0}` to name table `{1}`", name, table)
+        logger.debug(BraceMessage("Writing `{0}` to name table `{1}`", name, table))
         name = SgaPathResolver.fix_seperator(name)
         _, name = SgaPathResolver.parse(name)
         name = SgaPathResolver.strip_root(name)
@@ -1095,7 +1106,7 @@ class _V2TocDisassembler:  # pylint:disable=r0902
         return result
 
     def write_name_in_drive(self, drive: str, name: str = SgaPathResolver.ROOT) -> int:
-        logger.debug("Writing `{0}` in drive `{1}`", name, drive)
+        logger.debug(BraceMessage("Writing `{0}` in drive `{1}`", name, drive))
         name_table = self._get_or_make_name_table(drive)
         return self._write_name_to_table(name_table, name.lower())
 
@@ -2275,6 +2286,24 @@ class EssenceFSV2(EssenceFS):  # pylint: disable=r0902
             if in_memory is True:
                 self._unlazy()
 
+    def verify_sga_header(self, error: bool = False) -> Optional[bool]:
+        if self._lazy_file is None:
+            if error:
+                raise RelicToolError(
+                    "SGA header validation is only supported on lazy files. This SGA has been loaded into memory."
+                )
+            return None
+        return self._lazy_file.verify_header(error=error)
+
+    def verify_sga_file(self, error: bool = False) -> Optional[bool]:
+        if self._lazy_file is None:
+            if error:
+                raise RelicToolError(
+                    "SGA header validation is only supported on lazy files. This SGA has been loaded into memory."
+                )
+            return None
+        return self._lazy_file.verify_file(error=error)
+
     def _unlazy(self) -> None:
         """Converts the filesystem into an in-memory filesystem.
 
@@ -2561,7 +2590,7 @@ class EssenceFSV2(EssenceFS):  # pylint: disable=r0902
     def verify_file_crc(self, path: str, error: bool = False) -> bool:
         node: SgaFsFileV2 = self._getnode(path, exists=True)  # type: ignore
         if node.getinfo("basic").is_dir:
-            raise fs.errors.FileExists(path)
+            raise fs.errors.FileExpected(path)
         return node.verify_crc32(error)
 
     def close(self):  # type: () -> None

--- a/src/relic/sga/v2/serialization.py
+++ b/src/relic/sga/v2/serialization.py
@@ -1,6 +1,7 @@
 """Binary Serializers for Relic's SGA-V2."""
 
 from __future__ import annotations
+from relic.core.logmsg import BraceMessage
 
 import logging
 import os
@@ -397,8 +398,10 @@ class LazySgaTocFileDataHeaderV2Dow(
     def check_header_valid(self) -> bool:
         def _warn(name: str) -> None:
             logger.warning(
-                "Failed to parse File Data Header `{0}`, the header may be missing or invalid.",
-                name,
+                BraceMessage(
+                    "Failed to parse File Data Header `{0}`, the header may be missing or invalid.",
+                    name,
+                )
             )
 
         try:
@@ -451,13 +454,17 @@ class SgaTocFileDataV2:
             has_data_header and _lazy_data_header.check_header_valid()
         ):
             logger.debug(
-                "File `{0}` {1} a Data Header",
-                self.name,
-                "has" if has_safe_data_header else "may have",
+                BraceMessage(
+                    "File `{0}` {1} a Data Header",
+                    self.name,
+                    "has" if has_safe_data_header else "may have",
+                ),
             )
             self._data_header = _lazy_data_header
         else:
-            logger.debug("File `{0}` is missing its Data Header", self.name)
+            logger.debug(
+                BraceMessage("File `{0}` is missing its Data Header", self.name)
+            )
             _name = self.name
             _data = self.data(True).read(-1)
             self._data_header = MemSgaTocFileDataHeaderV2Dow.create(_name, _data)
@@ -472,7 +479,9 @@ class SgaTocFileDataV2:
 
     def data(self, decompress: bool = True) -> BinaryIO:
         logger.debug(
-            "Reading File Data from the Data Window (decompress={0})", decompress
+            BraceMessage(
+                "Reading File Data from the Data Window (decompress={0})", decompress
+            )
         )
         offset = self._toc_file.data_offset
         size = self._toc_file.compressed_size
@@ -631,10 +640,12 @@ class SgaFileV2(SgaFile):
         self._has_file_data_headers = _expected_data_size <= _data_size
         self._has_safe_file_data_headers = _expected_data_size == _data_size
         logger.debug(
-            "File `{0}` has {1} {2}Headers",
-            self._meta.name,
-            "" if self._has_file_data_headers else "No ",
-            "Exact " if self._has_safe_file_data_headers else "",
+            BraceMessage(
+                "File `{0}` has {1} {2}Headers",
+                self._meta.name,
+                "" if self._has_file_data_headers else "No ",
+                "Exact " if self._has_safe_file_data_headers else "",
+            )
         )
 
     def __determine_expected_data_window_size(self) -> int:
@@ -674,7 +685,7 @@ class SgaFileV2(SgaFile):
         return getattr(self, cache_name)  # type: ignore
 
     def verify_file(self, cached: bool = True, error: bool = False) -> bool:
-        logger.debug("Verifying `{0}` Header MD5", self._meta.name)
+        logger.debug(BraceMessage("Verifying `{0}` Header MD5", self._meta.name))
         NAME = "__verified_file"
         return self.__verify(
             cached=cached,
@@ -686,7 +697,7 @@ class SgaFileV2(SgaFile):
         )
 
     def verify_header(self, cached: bool = True, error: bool = False) -> bool:
-        logger.debug("Verifying `{0}` Header MD5", self._meta.name)
+        logger.debug(BraceMessage("Verifying `{0}` Header MD5", self._meta.name))
         NAME = "__verified_header"
         return self.__verify(
             cached=cached,


### PR DESCRIPTION
The more i look into this, the more confused I become,
Pylint supports checking new string format in logging, so why did it suddenly fail?
Does it only support ONE arg, or did i never check any log messages because my config level was too low?

Explicitly asks for Tool-Core v2.3 instead of relying on SGA-Core to ask for it via it's dependency, just to make sure we have the message objects

Regardless, should fix any logging issues
Closes https://github.com/MAK-Relic-Tool/Issue-Tracker/issues/59